### PR TITLE
ci(linters): add jscpd override to fix super-linter failure

### DIFF
--- a/.github/linters/.jscpd.json
+++ b/.github/linters/.jscpd.json
@@ -1,0 +1,4 @@
+{
+  "threshold": 2,
+  "ignore": ["**/.github/workflows/**"]
+}


### PR DESCRIPTION
The required `lint-workflows / lint workflows` check fails on every PR — including otherwise-green Dependabot PRs — with:

```
ERROR: jscpd found too many duplicates (0.3%) over threshold (0.0%)
```

**Cause**

super-linter runs JSCPD over the *whole workspace* (it ignores the workflow's `FILTER_REGEX_INCLUDE`). With no repo-local config it falls back to its built-in default `/action/lib/.automation/.jscpd.json`, which sets `threshold: 0` — so *any* duplication fails the build.

The only clone reported is org-standard reusable-workflow boilerplate that cannot be de-duplicated:

```
.github/workflows/add-to-project-*-dependabot.yaml
.github/workflows/add-to-project-*.yaml
```

**Fix**

Add `.github/linters/.jscpd.json` (super-linter’s default `LINTER_RULES_PATH`) ignoring `.github/workflows/**`.

Note this deliberately keeps a `threshold` of 2% rather than using an empty `{}` config. Several sibling repos use `{}`, but that **disables JSCPD entirely** — jscpd only enforces when `threshold` is set. Keeping a threshold means real copy/paste in source is still caught.

Verified locally with `jscpd@5.0.10` (the version super-linter ships): super-linter's default config exits 1 on this repo; with this override it exits 0.